### PR TITLE
removed the FloatingActionButton on from activity_login.xml

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -17,9 +17,4 @@
 
     <include layout="@layout/content_login" />
 
-    <android.support.design.widget.FloatingActionButton android:id="@+id/fab"
-        android:layout_width="wrap_content" android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end" android:layout_margin="@dimen/fab_margin"
-        android:src="@android:drawable/ic_dialog_email" />
-
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Simply removed the `FloatingActionButton` from the xml. The button was not referenced in `LoginActivity.java`, so it was not necessary to remove it from there also. This resolves issue #15 
### Before:

![before](https://cloud.githubusercontent.com/assets/6527677/11222280/364322f2-8d2f-11e5-8eed-b7fd2610ebd3.png)
### After:

![screenshot_2015-11-17_13-24-10](https://cloud.githubusercontent.com/assets/6527677/11222284/3f2653b2-8d2f-11e5-8e45-84b3ee098740.png)
