### PR TITLE
Unfavorite-ing events

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -65,10 +65,12 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/debug" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.1.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/23.1.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/mediarouter-v7/22.2.0/jars" />
@@ -102,12 +104,17 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services/8.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.melnykov/floatingactionbutton/1.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/multi-dex" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>

--- a/app/app.iml
+++ b/app/app.iml
@@ -65,12 +65,10 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/debug" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.1.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/23.1.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/mediarouter-v7/22.2.0/jars" />
@@ -104,17 +102,12 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services/8.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.melnykov/floatingactionbutton/1.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/multi-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>

--- a/app/src/main/java/acc/aviato/CreateEventActivity.java
+++ b/app/src/main/java/acc/aviato/CreateEventActivity.java
@@ -52,6 +52,8 @@ public class CreateEventActivity extends AppCompatActivity {
     Bitmap mBitmap;
     String[] tagArray;
 
+    boolean mSubmitted = false;
+
     TextView mLocationText;
     Button mEventLocationButton;
 
@@ -173,14 +175,15 @@ public class CreateEventActivity extends AppCompatActivity {
                             .setPositiveButton(android.R.string.ok, null);
                     AlertDialog alert = builder.create();
                     alert.show();
-                } else if (mGeoPoint == null){
+                } else if (mGeoPoint == null) {
                     AlertDialog.Builder builder = new AlertDialog.Builder(this);
                     builder.setMessage("You must select a location.")
                             .setTitle("Error")
                             .setPositiveButton(android.R.string.ok, null);
                     AlertDialog alert = builder.create();
                     alert.show();
-                } else {
+                } else if (!mSubmitted) {
+                    mSubmitted = true;
                     mEventObject = new ParseObject(ParseConstants.CLASS_EVENTS);
                     mEventObject.put(ParseConstants.KEY_SENDER_ID, ParseUser.getCurrentUser().getObjectId());
                     mEventObject.put(ParseConstants.KEY_SENDER_NAME, ParseUser.getCurrentUser().getUsername());
@@ -201,14 +204,13 @@ public class CreateEventActivity extends AppCompatActivity {
                     }
 
                     mEventObject.put(ParseConstants.KEY_EVENT_LOCATION, mGeoPoint);
-                    mEventObject.saveInBackground();
+
 
                     mEventObject.saveInBackground(new SaveCallback() {
                         @Override
                         public void done(ParseException e) {
                             if (e == null) {
                                 Toast.makeText(CreateEventActivity.this, "Event Uploaded", Toast.LENGTH_SHORT).show();
-                                CreateEventActivity.this.finish();
                             } else {
                                 AlertDialog.Builder builder = new AlertDialog.Builder(CreateEventActivity.this);
                                 builder.setMessage(e.getMessage() + "")
@@ -219,6 +221,8 @@ public class CreateEventActivity extends AppCompatActivity {
                             }
                         }
                     });
+
+                    CreateEventActivity.this.finish();
                 }
                 return true;
             case R.id.upload_photo:

--- a/app/src/main/java/acc/aviato/EventDetailActivity.java
+++ b/app/src/main/java/acc/aviato/EventDetailActivity.java
@@ -55,7 +55,14 @@ public class EventDetailActivity extends AppCompatActivity {
                     mEvent = parseObject;
                     eventName = mEvent.getString(ParseConstants.KEY_EVENT_NAME);
                     eventDescription = mEvent.getString(ParseConstants.KEY_EVENT_DESCRIPTION);
-                    // eventImageUri = Uri.parse(parseObject.getParseFile(ParseConstants.KEY_EVENT_IMAGE).getUrl());
+                    mEventNameView = (TextView) findViewById(R.id.event_name);
+                    mEventNameView.setText(eventName);
+
+                    mEventDescriptionView = (TextView) findViewById(R.id.event_description);
+                    mEventDescriptionView.setText(eventDescription);
+                    if (mEvent.getParseFile(ParseConstants.KEY_EVENT_IMAGE) != null) {
+                        eventImageUri = Uri.parse(parseObject.getParseFile(ParseConstants.KEY_EVENT_IMAGE).getUrl());
+                    }
                 } else {
                     // Failure (cannot find requested event of FeedFragment's listView)
                 }
@@ -63,12 +70,6 @@ public class EventDetailActivity extends AppCompatActivity {
         });
 
         // TODO: Remove uses of mIntent in favor of direct use of Parse queries
-
-        mEventNameView = (TextView) findViewById(R.id.event_name);
-        mEventNameView.setText(eventName);
-
-        mEventDescriptionView = (TextView) findViewById(R.id.eventDescription);
-        mEventDescriptionView.setText(eventDescription);
 
         mFavoriteButton = (Button) findViewById(R.id.favorite_button);
         // Get the user's favoriteEvents, if the current event is in the relation, remove it

--- a/app/src/main/java/acc/aviato/FeedFragment.java
+++ b/app/src/main/java/acc/aviato/FeedFragment.java
@@ -119,19 +119,9 @@ public class FeedFragment extends ListFragment implements GoogleApiClient.Connec
     @Override
     public void onListItemClick(ListView l, View v, int position, long id) {
         super.onListItemClick(l, v, position, id);
-
         Intent intent = new Intent(getActivity(), EventDetailActivity.class);
-        if (parseEvents.get(position).getParseFile(ParseConstants.KEY_EVENT_IMAGE) != null) {
-            ParseFile file = parseEvents.get(position).getParseFile(ParseConstants.KEY_EVENT_IMAGE);
-            Uri fileUri = Uri.parse(file.getUrl());
-            intent.setData(fileUri);
-        } else {
-            Log.d(TAG, "Null image found");
-        }
-        intent.putExtra("EVENT_NAME", parseEvents.get(position).getString(ParseConstants.KEY_EVENT_NAME));
-        intent.putExtra("EVENT_DESCRIPTION", parseEvents.get(position).getString(ParseConstants.KEY_EVENT_DESCRIPTION));
-        //needs address
-        intent.putExtra("EVENT_TAG", parseEvents.get(position).getString(ParseConstants.KEY_EVENT_TAG));
+        String objectId = parseEvents.get(position).getObjectId();
+        intent.putExtra(ParseConstants.KEY_EVENT_ID, objectId);
         startActivity(intent);
     }
 

--- a/app/src/main/java/acc/aviato/FeedFragment.java
+++ b/app/src/main/java/acc/aviato/FeedFragment.java
@@ -34,6 +34,7 @@ import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
 import com.melnykov.fab.FloatingActionButton;
 import com.parse.FindCallback;
+import com.parse.Parse;
 import com.parse.ParseException;
 import com.parse.ParseFile;
 import com.parse.ParseGeoPoint;
@@ -119,9 +120,23 @@ public class FeedFragment extends ListFragment implements GoogleApiClient.Connec
     @Override
     public void onListItemClick(ListView l, View v, int position, long id) {
         super.onListItemClick(l, v, position, id);
+
         Intent intent = new Intent(getActivity(), EventDetailActivity.class);
-        String objectId = parseEvents.get(position).getObjectId();
-        intent.putExtra(ParseConstants.KEY_EVENT_ID, objectId);
+        if (parseEvents.get(position).getParseFile(ParseConstants.KEY_EVENT_IMAGE) != null) {
+            ParseFile file = parseEvents.get(position).getParseFile(ParseConstants.KEY_EVENT_IMAGE);
+            Uri fileUri = Uri.parse(file.getUrl());
+            intent.setData(fileUri);
+        } else {
+            Log.d(TAG, "Null image found");
+        }
+        intent.putExtra("EVENT_NAME", parseEvents.get(position).getString(ParseConstants.KEY_EVENT_NAME));
+        intent.putExtra("EVENT_DESCRIPTION", parseEvents.get(position).getString(ParseConstants.KEY_EVENT_DESCRIPTION));
+        double latitude = parseEvents.get(position).getParseGeoPoint(ParseConstants.KEY_EVENT_LOCATION).getLatitude();
+        double longitude = parseEvents.get(position).getParseGeoPoint(ParseConstants.KEY_EVENT_LOCATION).getLongitude();
+        intent.putExtra("EVENT_LATITUDE", latitude);
+        intent.putExtra("EVENT_LONGITUDE", longitude);
+        intent.putExtra("EVENT_TAG", parseEvents.get(position).getString(ParseConstants.KEY_EVENT_TAG));
+        intent.putExtra("EVENT_ID", parseEvents.get(position).getObjectId());
         startActivity(intent);
     }
 
@@ -353,7 +368,7 @@ public class FeedFragment extends ListFragment implements GoogleApiClient.Connec
             }
             holder.votes.setText(mEvents.get(position).getInt(ParseConstants.KEY_EVENT_VOTES) + "");
             holder.event.setText(mEvents.get(position).getString(ParseConstants.KEY_EVENT_NAME));
-            //holder.date.setText(mEvents.get(position).getString(ParseConstants.KEY_EVENT_DATE))
+            holder.date.setText(mEvents.get(position).getString(ParseConstants.KEY_EVENT_DATE));
 
             holder.downArrow.setOnClickListener(new View.OnClickListener() {
                 @Override

--- a/app/src/main/java/acc/aviato/ParseConstants.java
+++ b/app/src/main/java/acc/aviato/ParseConstants.java
@@ -29,5 +29,6 @@ public final class ParseConstants {
     public static final String KEY_TAG_USAGE = "tagUsageCount";
 
     public static final String KEY_EVENT_LOCATION = "eventLocation";
+    public static final String KEY_EVENT_DATE = "eventDate";
 
 }

--- a/app/src/main/java/acc/aviato/ParseConstants.java
+++ b/app/src/main/java/acc/aviato/ParseConstants.java
@@ -10,6 +10,7 @@ public final class ParseConstants {
     public static final String CLASS_TAGS = "Tag";
 
     //field names - match what is already in parse and established from iOS
+    public static final String KEY_EVENT_ID = "objectId";   // Note: use getObjectId() to get ID of a specific object
     public static final String KEY_EVENT_NAME = "eventName";
     public static final String KEY_EVENT_TAG = "eventTags";
     public static final String KEY_EVENT_VOTES = "votes";

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -77,7 +77,7 @@
         android:src="@mipmap/arrow_down" />
 
     <TextView
-        android:id="@+id/eventDescription"
+        android:id="@+id/event_description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/event_name"


### PR DESCRIPTION
I made it so that EventDetailsActivity reads event's data directly from Parse (instead of everything being passed to it with Intent extras) and two queries. One to find this even directly on Parse, and another to get the current list of favorite events by a user. If the event does not exist in the list of favorited events, it is added. If it does exist, it is removed.

I also added a fix for multiple events being uploaded on a poor connection.
